### PR TITLE
Fetch rockets - Fetch data

### DIFF
--- a/src/components/Missions.jsx
+++ b/src/components/Missions.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { fetchMissions } from '../redux/missionsSlice';
@@ -10,7 +8,7 @@ const Missions = () => {
 
   useEffect(() => {
     dispatch(fetchMissions());
-  }, []);
+  }, [dispatch]);
 
   return (
     <div>

--- a/src/components/Rockets.jsx
+++ b/src/components/Rockets.jsx
@@ -1,5 +1,34 @@
-const Rockets = () => (
-  <div className="mt-5">Rockets</div>
-);
+import { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { fetchRockets } from '../redux/rocketsSlice';
+
+const Rockets = () => {
+  const { rockets } = useSelector((state) => state.rockets);
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    dispatch(fetchRockets());
+  }, [dispatch]);
+
+  return (
+    <div>
+      <h1>Rockets</h1>
+      <ul>
+        {rockets.map((rocket) => (
+          <li key={rocket.id}>
+            <strong>Name:</strong>
+            {' '}
+            {rocket.name}
+            ,
+            {' '}
+            <strong>Type:</strong>
+            {' '}
+            {rocket.type}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
 
 export default Rockets;

--- a/src/redux/rocketsSlice.js
+++ b/src/redux/rocketsSlice.js
@@ -1,9 +1,32 @@
-import { createSlice } from '@reduxjs/toolkit';
+import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
+import axios from 'axios';
+
+const URL = 'https://api.spacexdata.com/v3/rockets';
+
+export const fetchRockets = createAsyncThunk('rockets/fetchRockets', async (_, { rejectWithValue }) => axios.get(URL).then((response) => response.data.map(({
+  id, rocket_name: name, rocket_type: type, flickr_images: images,
+}) => ({
+  id, name, type, images,
+}))).catch((error) => rejectWithValue(error.message)));
+
+const initialState = {
+  loading: false,
+  rockets: [],
+  error: '',
+};
 
 const rocketsSlice = createSlice({
   name: 'rockets',
-  initialState: [],
+  initialState,
   reducers: {},
+  extraReducers: (builder) => {
+    builder
+      .addCase(fetchRockets.pending, (state) => ({ ...state, loading: true }))
+      .addCase(fetchRockets.fulfilled, (state, action) => (
+        { ...state, rockets: action.payload, loading: false }))
+      .addCase(fetchRockets.rejected, (state, action) => (
+        { ...state, error: action.payload, loading: false }));
+  },
 });
 
 export default rocketsSlice.reducer;

--- a/src/store.js
+++ b/src/store.js
@@ -1,9 +1,11 @@
 import { configureStore } from '@reduxjs/toolkit';
 import missionsReducer from './redux/missionsSlice';
+import rocketsReducer from './redux/rocketsSlice';
 
 const store = configureStore({
   reducer: {
     missions: missionsReducer,
+    rockets: rocketsReducer,
   },
 });
 


### PR DESCRIPTION
- Fetched data from the Rockets endpoint (https://api.spacexdata.com/v3/rockets) when the application starts (as Rockets is the default view).
- Once the data are fetched, dispatch an action to store the selected data in the Redux store:
  - id
  - name
  - type
  - flickr_images
- only dispatched actions once and did not add data to store on every re-render (i.e. when changing views / using navigation).