### PR TITLE
Switch badges for Rockets - Conditional components

### DIFF
--- a/src/components/Rockets.jsx
+++ b/src/components/Rockets.jsx
@@ -2,7 +2,7 @@
 import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import {
-  Button, Card, Stack, Container,
+  Button, Card, Stack, Container, Badge,
 } from 'react-bootstrap';
 import { cancelRocket, fetchRockets, reserveRocket } from '../redux/rocketsSlice';
 
@@ -26,7 +26,10 @@ const Rockets = () => {
               <Card.Img variant="top" src={images[0]} className="custom-width" />
               <Card.Body>
                 <Card.Title>{name}</Card.Title>
-                <Card.Text>{description}</Card.Text>
+                <Card.Text>
+                  {reserved && <Badge className="me-2">Reserved</Badge>}
+                  {description}
+                </Card.Text>
                 {reserved ? (<Button onClick={() => dispatch(cancelRocket(id))} variant="outline-secondary">Cancel Reservation</Button>)
                   : (<Button onClick={() => dispatch(reserveRocket(id))} variant="primary">Reserve Rocket</Button>)}
               </Card.Body>

--- a/src/components/Rockets.jsx
+++ b/src/components/Rockets.jsx
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import {
   Button, Card, Stack, Container,
 } from 'react-bootstrap';
-import { fetchRockets } from '../redux/rocketsSlice';
+import { fetchRockets, reserveRocket } from '../redux/rocketsSlice';
 
 const Rockets = () => {
   const { rockets } = useSelector((state) => state.rockets);
@@ -26,10 +26,9 @@ const Rockets = () => {
               <Card.Body>
                 <Card.Title>{name}</Card.Title>
                 <Card.Text>{description}</Card.Text>
-                <Button variant="primary">Learn More</Button>
+                <Button onClick={() => dispatch(reserveRocket(id))} variant="primary">Reserve Rocket</Button>
               </Card.Body>
             </Stack>
-
           </Container>
         </Card>
       ))

--- a/src/components/Rockets.jsx
+++ b/src/components/Rockets.jsx
@@ -1,9 +1,10 @@
+/* eslint-disable no-console */
 import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import {
   Button, Card, Stack, Container,
 } from 'react-bootstrap';
-import { fetchRockets, reserveRocket } from '../redux/rocketsSlice';
+import { cancelRocket, fetchRockets, reserveRocket } from '../redux/rocketsSlice';
 
 const Rockets = () => {
   const { rockets } = useSelector((state) => state.rockets);
@@ -17,7 +18,7 @@ const Rockets = () => {
     <>
       {
       rockets.map(({
-        id, name, images, description,
+        id, name, images, description, reserved,
       }) => (
         <Card key={id} className="mb-3 border-0">
           <Container fluid>
@@ -26,7 +27,8 @@ const Rockets = () => {
               <Card.Body>
                 <Card.Title>{name}</Card.Title>
                 <Card.Text>{description}</Card.Text>
-                <Button onClick={() => dispatch(reserveRocket(id))} variant="primary">Reserve Rocket</Button>
+                {reserved ? (<Button onClick={() => dispatch(cancelRocket(id))} variant="outline-secondary">Cancel Reservation</Button>)
+                  : (<Button onClick={() => dispatch(reserveRocket(id))} variant="primary">Reserve Rocket</Button>)}
               </Card.Body>
             </Stack>
           </Container>

--- a/src/redux/rocketsSlice.js
+++ b/src/redux/rocketsSlice.js
@@ -18,7 +18,18 @@ const initialState = {
 const rocketsSlice = createSlice({
   name: 'rockets',
   initialState,
-  reducers: {},
+  reducers: {
+    reserveRocket: (state, action) => {
+      const rocketId = action.payload;
+      const rockets = state.rockets.map((rocket) => {
+        if (rocket.id === rocketId) {
+          return { ...rocket, reserved: true };
+        }
+        return rocket;
+      });
+      return { ...state, rockets };
+    },
+  },
   extraReducers: (builder) => {
     builder
       .addCase(fetchRockets.pending, (state) => ({ ...state, loading: true }))
@@ -29,4 +40,5 @@ const rocketsSlice = createSlice({
   },
 });
 
+export const { reserveRocket } = rocketsSlice.actions;
 export default rocketsSlice.reducer;

--- a/src/redux/rocketsSlice.js
+++ b/src/redux/rocketsSlice.js
@@ -29,6 +29,16 @@ const rocketsSlice = createSlice({
       });
       return { ...state, rockets };
     },
+    cancelRocket: (state, action) => {
+      const rocketId = action.payload;
+      const rockets = state.rockets.map((rocket) => {
+        if (rocket.id === rocketId) {
+          return { ...rocket, reserved: false };
+        }
+        return rocket;
+      });
+      return { ...state, rockets };
+    },
   },
   extraReducers: (builder) => {
     builder
@@ -40,5 +50,5 @@ const rocketsSlice = createSlice({
   },
 });
 
-export const { reserveRocket } = rocketsSlice.actions;
+export const { reserveRocket, cancelRocket } = rocketsSlice.actions;
 export default rocketsSlice.reducer;


### PR DESCRIPTION
- Displayed the correct button(Reserve Rocket or Cancel Reservation button) based on reserved state.
- Rockets that have already been reserved should show a `Reserved` badge and `Cancel reservation` button instead of the default `Reserve rocket`.